### PR TITLE
Read job data from env vars provided by infrastructure target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,7 @@ run-local:
 
 build-docker:
 	cd sample/dockerfiled &&\
-	racetrack_job_wrapper template Dockerfile Dockerfile.templated &&\
-	docker buildx build -t sample-primer-job:latest -f Dockerfile.templated .
+	docker buildx build -t sample-primer-job:latest -f Dockerfile .
 
 run-docker: build-docker
 	docker run --rm -it --name sample-primer-job -p 7000:7000 sample-primer-job:latest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,23 @@ All **user-facing**, notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.4] - 2024-08-01
+### Changed
+- Job's metadata like name, version and manifest YAML are passed as environment variables: `JOB_NAME`, `JOB_VERSION` and `JOB_MANIFEST_YAML`.
+  They should be either provided by infrastructure target or set manually.
+  That means you no longer need to put
+  ```dockerfile
+  COPY ./job.yaml /project/job.yaml
+  ENV JOB_NAME="{{ manifest.name }}"
+  ENV JOB_VERSION="{{ manifest.version }}"
+  ```
+  in your Dockerfile.
+
+## [1.16.3] - 2024-08-01
+### Changed
+- `racetrack_client` and `racetrack_commons` modules has been moved under `racetrack_job_wrapper` package
+  to prevent conflicts with original `racetrack_client` package.
+
 ## [1.16.2] - 2024-07-30
 ### Changed
 - `pydantic` package is no longer a direct dependency of this library.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "racetrack_job_wrapper"
-version = "1.16.3"
+version = "1.16.4"
 description = "Racetrack Job Runner"
 license = {text = "Apache License 2.0"}
 authors = [

--- a/sample/dockerfiled/Dockerfile
+++ b/sample/dockerfiled/Dockerfile
@@ -17,5 +17,3 @@ RUN chmod -R a+rw /src/job/
 
 CMD ["bash", "-c", "python -u main.py"]
 LABEL racetrack-component="job"
-ENV JOB_NAME "{{ manifest.name }}"
-ENV JOB_VERSION "{{ manifest.version }}"

--- a/sample/dockerfiled/requirements.txt
+++ b/sample/dockerfiled/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/TheRacetrack/job-runner-python-lib.git@master#subdirectory=.
+git+https://github.com/TheRacetrack/job-runner-python-lib.git@master

--- a/src/racetrack_job_wrapper/standalone.py
+++ b/src/racetrack_job_wrapper/standalone.py
@@ -7,7 +7,7 @@ from racetrack_job_wrapper.api.asgi.asgi_reloader import ASGIReloader
 from racetrack_job_wrapper.entrypoint import JobEntrypoint
 from racetrack_job_wrapper.wrapper_api import create_api_app, create_health_app
 from racetrack_job_wrapper.health import HealthState
-from racetrack_job_wrapper.wrapper import read_job_manifest
+from racetrack_job_wrapper.wrapper import read_job_manifest_dict
 from racetrack_job_wrapper.log.context_error import ContextError
 from racetrack_job_wrapper.log.exception import short_exception_details, log_exception
 
@@ -50,7 +50,7 @@ def serve_job_instance(entrypoint: JobEntrypoint):
     but if your job initialization takes some time, use `serve_job_class` instead.
     """
     health_state = HealthState(live=True, ready=True)
-    manifest_dict = read_job_manifest()
+    manifest_dict = read_job_manifest_dict()
     app = create_api_app(entrypoint, health_state, manifest_dict)
     serve_asgi_app(app, http_addr='0.0.0.0', http_port=7000)
 
@@ -66,7 +66,7 @@ def _late_init(
         logger.info('Job instance created')
 
         health_state = HealthState(live=True, ready=True)
-        manifest_dict = read_job_manifest()
+        manifest_dict = read_job_manifest_dict()
         fastapi_app = create_api_app(entrypoint, health_state, manifest_dict)
 
         app_reloader.mount(fastapi_app)


### PR DESCRIPTION
These lines will no longer be needed in Dockerfile:
```dockerfile
COPY ./job.yaml /project/job.yaml
ENV JOB_NAME="{{ manifest.name }}"
ENV JOB_VERSION="{{ manifest.version }}"
```

Job's name, version and whole manifest YAML will be passed as env var, provided by Racetrack's infrastructure target (or manually)

It requires updating infrastructure targets to start providing manifest yaml