### PR TITLE
Fix metrics endpoint

### DIFF
--- a/src/racetrack_job_wrapper/api/metrics.py
+++ b/src/racetrack_job_wrapper/api/metrics.py
@@ -31,8 +31,3 @@ def setup_metrics_endpoint(api: FastAPI):
     metrics_app = make_wsgi_app(REGISTRY)
     api.mount('/metrics', WSGIMiddleware(metrics_app))
     TrailingSlashForwarder.mount_path('/metrics')
-
-    @api.get('/metrics', tags=['root'])
-    def _metrics_endpoint():
-        """List current Prometheus metrics"""
-        pass  # just register endpoint in swagger, it's handled by ASGI


### PR DESCRIPTION
Second definition of the metrics endpoint created entry in swagger documentation, but was also breaking the endpoint making it return null always. This change fixes metrics endpoint, but at the cost of losing swagger definition for this endpoint. 